### PR TITLE
fix: Faça a funçao percorrer todos os arquivos para serem processados

### DIFF
--- a/languages_dataset/tasks.py
+++ b/languages_dataset/tasks.py
@@ -61,6 +61,6 @@ def read_files():
     files_path = get_all_files_path(data_path)
     for file_path in files_path:
         parser = select_parser(file_path)
-        return parser.delay(file_path)
+        parser.delay(file_path)
 
 


### PR DESCRIPTION
Esta funçao utilizava apenas o primeiro arquivo, pois havia um comando `return` que parava a execuçao.