### PR TITLE
feat: Crie um volume nomeado para o rabbit

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       djangoAsynchronous:
         aliases:
           - rabbit
+    volumes:
+      - broker_volume:/var/lib/rabbitmq/
   tasks:
     image: app
     command: >
@@ -45,3 +47,7 @@ services:
 
 networks:
   djangoAsynchronous:
+
+volumes:
+  broker_volume:
+


### PR DESCRIPTION
Sem um volume nomeado, o docker cria um volume toda vez que subir o container